### PR TITLE
Iter8

### DIFF
--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -9,16 +9,20 @@ import (
 type Config struct {
 }
 
-var flagServerAddr string
-var flagReportInterval int
-var flagPollInterval int
-var flagUseJSON string
+var (
+	flagServerAddr     string
+	flagReportInterval int
+	flagPollInterval   int
+	flagUseJSON        bool
+	flagLogLevel       string
+)
 
 func parseFlags() {
 	flag.StringVar(&flagServerAddr, "a", "localhost:8080", "address and port to run server")
 	flag.IntVar(&flagReportInterval, "r", 2, "interval for metric send")
 	flag.IntVar(&flagPollInterval, "p", 1, "interval for collecting metrics")
-	flag.StringVar(&flagUseJSON, "j", "", "use JSON for metric sender")
+	flag.BoolVar(&flagUseJSON, "j", false, "use JSON for metric sender")
+	flag.StringVar(&flagLogLevel, "l", "INFO", "logger level")
 	flag.Parse()
 
 	if envRunAddr := os.Getenv("ADDRESS"); envRunAddr != "" {
@@ -30,9 +34,4 @@ func parseFlags() {
 	if envPollInterval, _ := strconv.Atoi(os.Getenv("POLL_INTERVAL")); envPollInterval != 0 {
 		flagPollInterval = envPollInterval
 	}
-	/*
-		 	if envJSONSend := os.Getenv("JSONSend"); envJSONSend != "" {
-				flagUseJSON = envJSONSend
-			}
-	*/
 }

--- a/internal/compress/compress.go
+++ b/internal/compress/compress.go
@@ -1,0 +1,98 @@
+package compress
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func Compress(data []byte) ([]byte, error) {
+	var b bytes.Buffer
+	// создаём переменную w — в неё будут записываться входящие данные,
+	// которые будут сжиматься и сохраняться в bytes.Buffer
+	w, err := gzip.NewWriterLevel(&b, gzip.BestSpeed)
+	if err != nil {
+		return nil, fmt.Errorf("failed init compress writer: %w", err)
+	}
+	// запись данных
+	_, err = w.Write(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed write data to compress temporary buffer: %w", err)
+	}
+	// обязательно нужно вызвать метод Close() — в противном случае часть данных
+	// может не записаться в буфер b; если нужно выгрузить все упакованные данные
+	// в какой-то момент сжатия, используйте метод Flush()
+	err = w.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed compress data: %w", err)
+	}
+	// переменная b содержит сжатые данные
+	return b.Bytes(), nil
+}
+
+// compressWriter реализует интерфейс http.ResponseWriter и позволяет прозрачно для сервера
+// сжимать передаваемые данные и выставлять правильные HTTP-заголовки.
+type compressWriter struct {
+	w  http.ResponseWriter
+	zw *gzip.Writer
+}
+
+func NewCompressWriter(w http.ResponseWriter) *compressWriter {
+	return &compressWriter{
+		w:  w,
+		zw: gzip.NewWriter(w),
+	}
+}
+
+func (c *compressWriter) Header() http.Header {
+	return c.w.Header()
+}
+
+func (c *compressWriter) Write(p []byte) (int, error) {
+	return c.zw.Write(p)
+}
+
+func (c *compressWriter) WriteHeader(statusCode int) {
+	if statusCode < 300 {
+		c.w.Header().Set("Content-Encoding", "gzip")
+		c.w.Header().Del("Content-Length")
+	}
+	c.w.WriteHeader(statusCode)
+}
+
+// Close закрывает gzip.Writer и досылает все данные из буфера.
+func (c *compressWriter) Close() error {
+	return c.zw.Close()
+}
+
+// compressReader реализует интерфейс io.ReadCloser и позволяет прозрачно для сервера
+// декомпрессировать получаемые от клиента данные.
+type compressReader struct {
+	r  io.ReadCloser
+	zr *gzip.Reader
+}
+
+func NewCompressReader(r io.ReadCloser) (*compressReader, error) {
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &compressReader{
+		r:  r,
+		zr: zr,
+	}, nil
+}
+
+func (c compressReader) Read(p []byte) (n int, err error) {
+	return c.zr.Read(p)
+}
+
+func (c *compressReader) Close() error {
+	if err := c.r.Close(); err != nil {
+		return err
+	}
+	return c.zr.Close()
+}


### PR DESCRIPTION
This MR adds gzip compression support to the agent to reduce network traffic.
Logger levels were adjusted to better reflect actual severity.
JSON metrics sending flag was fixed to ensure correct format is used.

Tests: TestIteration1–TestIteration8
metricstest-darwin-arm64 -test.v -test.run='^TestIteration8$' -binary-path=cmd/server/server -agent-binary-path=cmd/agent/agent -source-path=. -server-port=12345